### PR TITLE
calculate a more accurate fee based without rounding to the nearest kB

### DIFF
--- a/lib/transaction/transaction.js
+++ b/lib/transaction/transaction.js
@@ -910,11 +910,11 @@ Transaction.prototype._clearSignatures = function() {
 };
 
 Transaction._estimateFee = function(size, amountAvailable, feePerKb) {
-  var fee = Math.ceil(size / 1000) * (feePerKb || Transaction.FEE_PER_KB);
+  var fee = Math.ceil(size / 1000 * (feePerKb || Transaction.FEE_PER_KB));
   if (amountAvailable > fee) {
     size += Transaction.CHANGE_OUTPUT_MAX_SIZE;
   }
-  return Math.ceil(size / 1000) * (feePerKb || Transaction.FEE_PER_KB);
+  return Math.ceil(size / 1000 * (feePerKb || Transaction.FEE_PER_KB));
 };
 
 Transaction.prototype._estimateSize = function() {


### PR DESCRIPTION
the original code rounds the size to the nearest 1k and calculated the fees based on that which ends up being higher than it needs to be.  this fix bases the fee on the true size, in KB, then rounds it up