### PR TITLE
add a `noSorting` option to the multi sig inputs

### DIFF
--- a/lib/transaction/input/multisig.js
+++ b/lib/transaction/input/multisig.js
@@ -17,13 +17,17 @@ var TransactionSignature = require('../signature');
 /**
  * @constructor
  */
-function MultiSigInput(input, pubkeys, threshold, signatures) {
+function MultiSigInput(input, pubkeys, threshold, signatures, opts) {
   Input.apply(this, arguments);
   var self = this;
   pubkeys = pubkeys || input.publicKeys;
   threshold = threshold || input.threshold;
   signatures = signatures || input.signatures;
-  this.publicKeys = _.sortBy(pubkeys, function(publicKey) { return publicKey.toString('hex'); });
+  if (opts && opts.noSorting) {
+    this.publicKeys = pubkeys;
+  } else {
+    this.publicKeys = _.sortBy(pubkeys, function(publicKey) { return publicKey.toString('hex'); });
+  }
   $.checkState(Script.buildMultisigOut(this.publicKeys, threshold).equals(this.output.script),
     'Provided public keys don\'t match to the provided output script');
   this.publicKeyIndex = {};

--- a/lib/transaction/input/multisigscripthash.js
+++ b/lib/transaction/input/multisigscripthash.js
@@ -19,7 +19,7 @@ var TransactionSignature = require('../signature');
 /**
  * @constructor
  */
-function MultiSigScriptHashInput(input, pubkeys, threshold, signatures, nestedWitness) {
+function MultiSigScriptHashInput(input, pubkeys, threshold, signatures, nestedWitness, opts) {
   /* jshint maxstatements:20 */
   Input.apply(this, arguments);
   var self = this;
@@ -27,7 +27,11 @@ function MultiSigScriptHashInput(input, pubkeys, threshold, signatures, nestedWi
   threshold = threshold || input.threshold;
   signatures = signatures || input.signatures;
   this.nestedWitness = nestedWitness ? true : false;
-  this.publicKeys = _.sortBy(pubkeys, function(publicKey) { return publicKey.toString('hex'); });
+  if(opts && opts.noSorting) {
+    this.publicKeys = pubkeys;
+  } else {
+    this.publicKeys = _.sortBy(pubkeys, function(publicKey) { return publicKey.toString('hex'); });
+  }
   this.redeemScript = Script.buildMultisigOut(this.publicKeys, threshold);
   if (this.nestedWitness) {
     var nested = Script.buildWitnessMultisigOutFromScript(this.redeemScript);


### PR DESCRIPTION
the current implementation is very inflexible and forces key sorting on multi-sig wallets.  this can lead to incompatibility with other wallets.  This PR adds a `noSorting` option (defaults to false - current logic) to allow for compatibility with other wallets